### PR TITLE
DEV-4416: Integrate Siklu unit tests to: github.com/siklu/pyangbind/tree/master/tests

### DIFF
--- a/tests/serialise/xml-deserialise/radio-bridge-tg-radio-common.yang
+++ b/tests/serialise/xml-deserialise/radio-bridge-tg-radio-common.yang
@@ -1,0 +1,971 @@
+module radio-bridge-tg-radio-common {
+
+    yang-version "1";
+
+// namespace
+    namespace "http://siklu.com/yang/tg/radio";
+
+    prefix rb-tg-radio;
+    import ietf-yang-types {
+        prefix yang;
+        revision-date 2013-07-15;
+    }
+    import radio-bridge-tg-types {
+        prefix "rb-tg-types";
+        revision-date 2021-05-25;
+    }
+
+// meta
+    organization
+      "Siklu";
+
+    contact
+      "Support: <https://siklu.com/contact/>";
+
+    description
+      "This YANG module is part of radio-bridge TG project.
+        It defines the radio part of the project";
+
+    revision 2021-11-18 {
+        description
+          "1.2.0 release";
+        reference
+          "";
+    }
+
+    revision 2021-05-25 {
+        description
+          "Release";
+        reference
+          "";
+    }
+
+    revision 2021-04-21 {
+        description
+          "Initial Revision";
+        reference
+          "";
+    }
+
+// extension statements
+// feature statements
+// identity statements
+// typedef statements
+    typedef golay-index {
+        type  enumeration {
+            enum unspecified {
+                description
+                  "Not specified in this level";
+            }
+            enum 1 {
+                description
+                  ""; // TODO
+            }
+            enum 2 {
+                description
+                  ""; // TODO
+            }
+        }
+        default "unspecified";
+        description
+          "Index of the radio Golay code sequence. 
+           Must be specified in TG node defaults and/or for each sector.
+           Could be overridden in link
+           Based on TG radio definitions.";
+    }
+
+    typedef polarity-type {
+        type enumeration {
+            enum unspecified {
+                description
+                  "Not specified in this level";
+            }
+            enum even {
+                description
+                  "even polarity";
+            }
+            enum hybrid-even {
+                description
+                  "hybrid-even polarity";
+            }
+            enum odd {
+                description
+                  "odd polarity";
+            }
+            enum hybrid-odd {
+                description
+                  "hybrid-odd polarity";
+            }
+        }
+        default "unspecified";
+        description
+          "Time slot parameter to reduce interference from other TG nodes.
+            Must be specified in TG node defaults and/or for each sector.
+            According to TG radio definitions.";
+    }
+
+    typedef frequency-channel {
+        type  enumeration {
+            enum unspecified {
+                description
+                  "Not specified in this level";
+            }
+            enum 58320 {
+                description
+                  "RF channel 1, 58320MHz";
+            }
+            enum 60480 {
+                description
+                  "RF channel 2, 60480MHz";
+            }
+            enum 62640 {
+                description
+                  "RF channel 3, 62640MHz";
+            }
+            enum 64800 {
+                description
+                  "RF channel 4, 64800MHz";
+            }
+        }
+        units "MHz";
+        default "unspecified";
+        description
+          "Frequency of the radio channel.
+           Must be specified in TG node defaults and/or for each sector.";
+    }
+
+    typedef control-superframe {
+        type enumeration {
+            enum 0 {
+                description
+                  "Control superframe 0";
+            }
+            enum 1 {
+                description
+                  "Control superframe 1";
+            }
+            enum unspecified {
+                description
+                  "Control superframe is unspecified, only valid for node-node links";
+            }
+        }
+        default "unspecified";
+        description
+          "Time slot at which the local node exchanges control information with the remote node.";
+    }
+
+    typedef link-role {
+        type enumeration {
+            enum initiator {
+                description
+                  "The local node initiated the link";
+            }
+            enum responder {
+                description
+                  "The local node accepted the link";
+            }
+        }
+        description
+          "Whether the local node initiated the link or responded to the link request";
+    }
+    typedef ssid-name {
+        type rb-tg-types:radio-bridge-tg-string {
+            length "8..61";
+        }
+        description
+          "A string Identifier of the radio network";
+    }
+
+    typedef rf-link-password {
+        type rb-tg-types:radio-bridge-tg-string {
+            length "8..61";
+        }
+        description
+          "A password for the radio network";
+    }
+    typedef node-type {
+        type enumeration {
+            enum dn {
+                description
+                  "The TG unit is a Distribution Node";
+            }
+            enum cn {
+                description
+                  "The TG unit is a Client Node";
+            }
+        }
+        description
+          "Whether the TG unit is a distribution or a client node. A TU node is always CN";
+    }
+
+    typedef rssi-type {
+        type union {
+            type int8;
+            type rb-tg-types:value-not-available;
+        }
+        units "dBm";
+        description
+          "Received signal strength indicator, measured during management packets";
+    }
+
+    typedef snr-type {
+        type union {
+            type int8;
+            type rb-tg-types:value-not-available;
+        }
+        units "dB";
+        description
+          "Signal-to-Noise Ratio";
+    }
+
+    typedef mcs-index-type {
+        type union {
+            type uint8;
+            type rb-tg-types:value-not-available;
+        }
+        description
+          "Modulation and coding scheme index";
+    }
+
+    typedef tx-power-index-type {
+        type union {
+            type uint8{
+                range 0..31;
+            }
+            type rb-tg-types:value-not-available;
+        }
+        description
+          "Transmit power in relative units.
+           For MCS 10 and higher the index limit is 25, for MCS 9 and lower the limit is 31.";
+    }
+
+    typedef rf-link-speed-type {
+        type union {
+            type uint16;
+            type rb-tg-types:value-not-available;
+        }
+        units "Mbps";
+        description
+          "Over-the-air (OTA) rate, in Mbps";
+    }
+
+    typedef per-rate-type {
+        type union {
+            type decimal64 {
+                fraction-digits 2;
+            }
+            type rb-tg-types:value-not-available;
+        }
+        units "percent";
+        description
+          "Packet Error Rate (PER), in percentage";
+    }
+    typedef sync-mode-type {
+        type enumeration {
+            enum rf {
+                description
+                  "The RF is used for syncing";
+            }
+            enum internal {
+                description
+                  "Internal system is used for syncing";
+            }
+            enum no-sync {
+                description
+                  "No syncing is in progress";
+            }
+        }
+        description
+          "type of sector syncing either by internal system, RF, or no syncing";
+    }
+    typedef sector-mode {
+        type union {
+            type enumeration {
+                enum down {
+                    description
+                      "The sector is set to admin down";
+                }
+                enum uninitialized {
+                    description
+                      "Sector's starting state. 
+                       Listening for links on every channel, polarity and Golay index. 
+                       Can not initiate links.";
+                }
+                enum cn-link-up {
+                    description
+                      "The sector has an incoming link.
+                       Applicable only for CN nodes.";
+                }
+                enum initialized {
+                    description
+                      "The sector's channel and polarity parameters are configured. 
+                       Does not listen for links.
+                       Applicable only for DN nodes.";
+                }
+                enum responder {
+                    description
+                      "The sector is initialized and listening for an incoming link (with its configured parameters).
+                       All configured sectors enter this state if non of the sectors have incoming links.
+                       The sector might have links it initiated previously.
+                       Applicable only for DN nodes.";
+                }
+                enum link-ignition {
+                    description
+                      "The sector is trying the initiate a link.
+                       Applicable only for DN nodes.";
+                }
+            }
+            type rb-tg-types:value-not-available;
+        }
+        description
+          "The mode of a sector: configuration state and whether or not it is trying to initiate links or listen for them.";
+    }
+
+    typedef operation-mode-type {
+        type enumeration {
+            enum BU {
+                description
+                  "The unit will operate as a base unit. In this operational mode the unit can do the following:
+                   1. connect to incoming connection requests from other BU units. 
+                   2. initialize connection to other BU or TU units.";
+            }
+            enum TU {
+                description
+                  "The unit will operate as a terminal unit. In this operational mode the unit can 
+                   connect to incoming connection requests from other BU units.";
+            }
+            enum P2P {
+                description
+                  "The unit will operate as a long reach unit. In this operational mode the unit can do the following:
+                   1. connect to incoming connection requests from other P2P units. 
+                   2. initialize connection to other P2P units.";
+            }
+        }
+        description
+          "Whether the unit will operate as a base, terminal or a long reach unit";
+    }
+    typedef beam-index-type {
+        type union {
+            type uint16;
+            type rb-tg-types:value-not-available;
+        }
+        description
+          "Tx/Rx beam index";
+    }
+    typedef beam-angle-type {
+        type union {
+            type int16 {
+                range -180..180;
+            }
+            type rb-tg-types:value-not-available;
+        }
+        units "degrees";
+        description
+          "Beam direction for azimuth or elevation";
+    }
+
+    typedef link-distances-type {
+        type enumeration {
+            enum Normal {
+                description
+                  "Mode for links of short distances.";
+            }
+            enum Long {
+                description
+                  "Mode for links of long distances.";
+            }
+            enum Extra-long {
+                description
+                  "Mode for links of extra-long distances.";
+            }
+        }
+        description
+          "The distance mode of a link. Higher distance modes have lower data rates.
+           A higher distance mode will work for a shorter distance than intended 
+           (with a reduced data rate), however the opposite will not work.";
+    }
+
+    typedef tx-power-control-type {
+        type union {
+            type  enumeration {
+                enum auto {
+                    value 0;
+                    description
+                      "ATPC enabled";
+                }
+                enum max {
+                    value 31;
+                    description
+                      "tx-power-index = 31";
+                }
+                enum min {
+                    value 6;
+                    description
+                      "tx-power-index = 6";
+                }
+            }
+            type tx-power-index-type;
+        }
+        description
+          "tx-power index to be locked for alignment";
+    }
+    typedef link-down-cause {
+        type enumeration {
+            enum SystemError {
+                description
+                  "The system has experienced an unexpected but recoverable error
+                   while igniting this link.";
+            }
+            enum NoGpsSync {
+                description
+                  "Could no synchronize with GPS.";
+            }
+            enum LinkTrainingFailed {
+                description
+                  "Could not complete the link training procedure. That can indicate
+                   invalid polarity, remote unit name, configuration and invalid
+                   physical configuration.";
+            }
+            enum HeartbeatLossDetected {
+                description
+                  "Heartbeat loss detected: that usually indicates of a poor radio
+                   connectivity or a lot of noise which caused the link not be able
+                   to stay up.";
+            }
+            enum LinkNegotiationFailed {
+                description
+                  "Could not complete ignition due to link negotiation and state of
+                   the other peer: that can indicate of an invalid ssid / password.";
+            }
+            enum LinkUpChannelChanged {
+                description
+                  "Channel has been changed, but the sector has a link up with a different
+                   channel (usually happens when the sector is a responder and tries to
+                   change the channel)";
+            }
+        }
+        description
+          "Explains down cause of not connected links";
+    }
+// grouping statements
+    grouping node-top {
+        container node-config {
+            description
+              "The container includes all the configuration that are related to the entire node.";
+            container default-ssid-profile {
+                uses ssid-profile;
+                description
+                  "Defaults for ssid configuration. Applies also to sectors without specified SSID configuration";
+            }
+            leaf operation-mode {
+                type operation-mode-type;
+                description
+                  "The unit will operate in this mode. The options are: BU, TU or P2P.
+                   When moving from P2P to BU or TU and vice versa, a system reboot is needed.";
+            }
+            leaf link-distance {
+                type link-distances-type;
+                default Long;
+                description
+                  "The distance mode of the link. The options are: Normal, Long and Extra-long.
+                   Changing the distance mode requires a system reboot.";
+            }
+            list available-operation-mode {
+                key "operation-mode";
+                config false;
+                leaf operation-mode {
+                    type operation-mode-type;
+                    description
+                      "The unit can operate in this mode";
+                }
+                description
+                  "A list of operational modes that the unit can be switched to";
+            }
+            leaf tx-power-control {
+                type tx-power-control-type;
+                
+                description
+                  "lock txPower to 6, 31, auto for purpose of naive alignment 
+                    for entire node";
+            }
+        }
+        description
+          "Grouping for node configuration and defaults";
+    }
+
+    grouping radio-frequency {
+        leaf frequency {
+            type frequency-channel;
+            description
+              "Channel frequency index";
+        }
+        description
+          "Radio frequency grouping";
+    }
+    grouping radio-polarity {
+        leaf polarity {
+            type polarity-type;
+            description
+              "Polarity type";
+        }
+        description
+          "Radio polarity grouping";
+    }
+    grouping radio-golay-index {
+        leaf tx-golay-index {
+            type golay-index;
+            description
+              "Tx Golay index of Golay code sequence";
+        }
+        leaf rx-golay-index {
+            type golay-index;
+            description
+              "Rx Golay index of Golay code sequence";
+        }
+        description
+          "Radio golay index grouping for both Rx and Tx";
+    }
+
+    grouping ssid-profile {
+        leaf ssid {
+            type ssid-name;
+            default "MultiHaul";
+            description
+              "A string Identifier of the radio network";
+        }
+        leaf password {
+            type rf-link-password;
+            default "MultiHaul";
+            description
+              "The password for the radio network";
+        }
+        description
+          "SSID parameters";
+    }
+
+    grouping sectors-top {
+        container sectors-config {
+            description
+              "Contain all parameters for sectors";
+            list sector {
+                key index;
+                leaf index {
+                    type rb-tg-types:radio-sector-index;
+                    description
+                      "The index of the sector";
+                }
+                leaf alias {
+                    type string{
+                        length "1..20";
+                    }
+                    description
+                      "The alias name of sector given by user.";
+                }
+                leaf admin-status {
+                    type rb-tg-types:admin-status;
+                    description
+                      "Whether the sector is configured up (enabled) or down (disabled)";
+                }
+
+                container state {
+                    config false;
+                    leaf mac-addr {
+                        type yang:mac-address;
+                        description
+                          "MAC address of the local sector";
+                    }
+                    leaf sector-state {
+                        type sector-mode;
+                        description
+                          "Current mode of sector";
+                    }
+                    uses radio-frequency;
+                    leaf sync-mode {
+                        type sync-mode-type;
+                        description
+                          "type of sector syncing either by GPS or RF";
+                    }
+                    container temperatures {
+                        leaf modem-temperature {
+                            type rb-tg-types:temperature-celsius;
+                            description
+                              "Sector's modem temperature, in Celsius";
+                        }
+                        list rf {
+                            key index;
+                            leaf index {
+                                type uint8;
+                                description
+                                  "Sector RF index";
+                            }
+                            leaf rf-temperature {
+                                type rb-tg-types:temperature-celsius;
+                                description
+                                  "RF temperature, in Celsius";
+                            }
+                            description
+                              "List of the RF temperatures";
+                        }
+                        description
+                          "The temperatures of the Sector's components.";
+                    }
+
+                    description
+                      "The state of the sector";
+                }
+                description
+                  "List of all sectors";
+            }
+        }
+        description
+          "Grouping for sectors configuration and default configuration data";
+    }
+
+    grouping link-state-counters {
+        description
+          "counters for a link";
+
+        leaf rx-ok {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Number of successfully received frames/MPDUs.";
+        }
+        leaf tx-ok {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Number of successfully transmitted frames/MPDUs.";
+        }
+        leaf tx-fail {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Number of transmission failures.";
+        }
+        leaf rx-fail {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Number of CRC failed frames received (Once CRC fail, cannot trust RA as well).";
+        }
+        leaf rx-hcs-fail {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Number of received frames with HCS failed PLCP header.";
+        }
+        leaf tx-failures {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Total number of TX packets dropped due to lifetime expiry.";
+        }
+        leaf rx-failures {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Total number of RX packets failures.";
+        }
+        leaf rx-drop-buf-size {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Total RX Discard count due to Buffer overflow.";
+        }
+        leaf rx-drop-encryption-fail {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Total RX Discard count due to Encryption failure.";
+        }
+        leaf rx-drop-ra-mismatch {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Total RX Discard count due to RA mismatch.";
+        }
+        leaf rx-drop-unexpected {
+            type union {
+                type uint64;
+                type rb-tg-types:value-not-available;
+            }
+            description
+              "Total RX Discard count due to other unexpected reasons or PER emulator.";
+        }
+    }
+    grouping beam-info {
+        leaf beam-index {
+            type beam-index-type;
+            description
+              "Index of active beam";
+        }
+        leaf beam-azimuth {
+            type beam-angle-type;
+            description
+              "Azimuth direction of active beam";
+        }
+        leaf beam-elevation {
+            type beam-angle-type;
+            description
+              "Elevation direction of active beam";
+        }
+        description
+          "Beam information for TX or RX beam";
+    }
+    grouping active-link-health-state {
+        description
+          "link health status values";
+
+        leaf rssi {
+            type rssi-type;
+            description
+              "Received Signal Strength Indicator";
+        }
+        leaf snr {
+            type snr-type;
+            description
+              "Signal-to-Noise Ratio";
+        }
+        leaf mcs-rx {
+            type mcs-index-type;
+            description
+              "modulation and coding scheme index of Rx";
+        }
+        leaf mcs-tx {
+            type mcs-index-type;
+            description
+              "modulation and coding scheme index of Tx";
+        }
+        leaf tx-per {
+            type per-rate-type;
+            description
+              "Packet Error Rate (PER), in percentage. 2 fraction-digits accuracy";
+        }
+        leaf rx-per {
+            type per-rate-type;
+            description
+              "Packet Error Rate (PER), in percentage. 2 fraction-digits accuracy";
+        }
+        leaf tx-power-index {
+            type tx-power-index-type;
+            description
+              "Transmit power index (relative). Range: 0-31";
+        }
+        leaf speed-rx {
+            type rf-link-speed-type;
+            description
+              "Rx OTA data speed (Mbps)";
+        }
+        leaf speed-tx {
+            type rf-link-speed-type;
+            description
+              "Tx OTA data speed (Mbps)";
+        }
+
+        container tx-beam {
+            uses beam-info;
+            description
+              "Active Tx beam";
+        }
+        container rx-beam {
+            uses beam-info;
+            description
+              "Active Rx beam";
+        }
+        container counters {
+            description
+              "Link's counters";
+            uses link-state-counters;
+        }
+    }
+
+    // Unused
+    grouping link-state-instantaneous-counters {
+        description
+          "Instantaneous counters for a link";
+        leaf rx-packets {
+            type uint64;
+            description
+              "Receive packets/second";
+        }
+        leaf rx-bytes {
+            type uint64;
+            description
+              "Received bytes/second";
+        }
+        leaf rx-errors {
+            type uint64;
+            description
+              "Received errors/second";
+        }
+        leaf rx-dropped {
+            type uint64;
+            description
+              "Receive dropped/second";
+        }
+
+        leaf tx-packets {
+            type uint64;
+            description
+              "Transmit packets/second";
+        }
+        leaf tx-bytes {
+            type uint64;
+            description
+              "Transmit bytes/second";
+        }
+        leaf tx-errors {
+            type uint64;
+            description
+              "Transmit errors/second";
+        }
+        leaf tx-dropped {
+            type uint64;
+            description
+              "Transmit dropped/second";
+        }
+    }
+
+    grouping active-link-state {
+        description
+          "Contains a link status data";
+        leaf remote-assigned-name {
+            type rb-tg-types:node-assigned-name;
+            description
+              "The network Assigned Name/ID of the remote unit";
+        }
+        leaf actual-remote-sector-index {
+            type rb-tg-types:radio-sector-index;
+            description
+              "The remote sector index that the link is associated to (in the remote unit)";
+        }
+        leaf actual-local-sector-index {
+            type rb-tg-types:radio-sector-index;
+            description
+              "The local sector index that the link is associated from";
+        }
+        leaf remote-mac-addr {
+            type yang:mac-address;
+            description
+              "MAC address of the remote sector";
+        }
+        leaf local-role {
+            type link-role;
+            description
+              "Describes whether the local unit initiated the link or responded to it";
+        }
+        leaf link-uptime {
+            type uint64;
+            units "seconds";
+            description
+              "Total uptime of link since its initiation. The time is presented in seconds";
+        }
+        uses active-link-health-state;
+    }
+
+    grouping disconnected-link-state {
+        description
+          "Contains a disconnected link cause data";
+        list local-sector {
+            key index;
+            description
+              "A list of local-sectors which received response during disconnection";
+            leaf index {
+                type rb-tg-types:radio-sector-index;
+                description
+                  "The index of the local sector";
+            }
+            list remote-sector {
+                key index;
+                description
+                  "A list of remote-sectors from received response during disconnection";
+                leaf index {
+                    type rb-tg-types:radio-sector-index;
+                    description
+                      "The index of the remote sector";
+                }
+                leaf down-cause {
+                    type link-down-cause;
+                    description
+                      "Explains down cause.";
+                }
+                leaf last-update {
+                    type string;
+                    description
+                      "Timestamp of latest down-cause";
+                }
+            }
+        }
+    }
+    grouping links-top {
+        container links {
+            config false;
+            list active {
+                uses active-link-state;
+                key remote-assigned-name;
+                config false;
+
+                description
+                  "A list of all connected links (initiated and responded)";
+            }
+            list disconnected {
+                uses disconnected-link-state;
+                leaf remote-assigned-name {
+                    type rb-tg-types:node-assigned-name;
+                    description
+                      "The network Assigned Name/ID of the remote unit";
+                }
+                key remote-assigned-name;
+                config false;
+
+                description
+                  "A list of all disconnected links (that were once initiated)";
+            }
+            description
+              "Contains lists of all links";
+        }
+        description
+          "Contains all links configuration";
+    }
+
+    grouping radio-top {
+        container radio-common {
+            description
+              "Top level container for TG unit radio information";
+            uses node-top;
+            uses sectors-top;
+            uses links-top;
+        }
+        description
+          "Top level grouping of radio data";
+    }
+
+    // data definition statements
+    uses radio-top;
+    // rpc statements
+    rpc clear-all-fw-counters {
+        description
+          "RPC for clearing the FW counters for all links";
+    }
+}

--- a/tests/serialise/xml-deserialise/radio-bridge-tg-radio-dn.yang
+++ b/tests/serialise/xml-deserialise/radio-bridge-tg-radio-dn.yang
@@ -1,0 +1,311 @@
+module radio-bridge-tg-radio-dn {
+
+    yang-version "1";
+
+    // namespace
+    namespace "http://siklu.com/yang/tg/radio/dn";
+
+    prefix rb-tg-radio-dn;
+    import radio-bridge-tg-radio-common {
+        prefix "rb-tg-radio";
+        revision-date 2021-11-18;
+    }
+    import radio-bridge-tg-types {
+        prefix "rb-tg-types";
+        revision-date 2021-05-25;
+    }
+
+    // meta
+    organization
+      "Siklu";
+
+    contact
+      "Support: <https://siklu.com/contact/>";
+
+    description
+      "This YANG module is part of radio-bridge TG project.
+        It defines the dn radio part of the project";
+
+    revision 2021-11-25 {
+        description
+          "Removed ignore-gps added sync-mode";
+        reference
+          "";
+    }
+
+    revision 2021-11-18 {
+        description
+          "1.2.0 release";
+        reference
+          "";
+    }
+
+    revision 2021-05-25 {
+        description
+          "Release";
+        reference
+          "";
+    }
+
+    revision 2020-11-22 {
+        description
+          "Initial Revision";
+        reference
+          "";
+    }
+
+    // extension statements
+    // feature statements
+    // identity statements
+    // typedef statements
+    typedef dn-link-state-type {
+        type enumeration {
+            enum Connected {
+                description
+                  "The link is connected";
+            }
+            enum LinkAdminDown {
+                description
+                  "Link admin state is down";
+            }
+            enum SectorAdminDown {
+                description
+                  "Local sectors of the link are down";
+            }
+            enum WaitingUpstreamConnection {
+                description
+                  "Waiting for pop-dn";
+            }
+            enum WaitingInQueue {
+                description
+                  "Waiting in queue";
+            }
+            enum Ignition {
+                description
+                  "Link ignition in progress";
+            }
+        }
+        description
+          "Possible states of ignition. Items are ordered by displaying priority";
+    }
+
+    typedef dn-sync-mode-type {
+        type enumeration {
+            enum no-sync {
+                description
+                  "Allows link creation without GPS. This is practical for indoor link tests
+                   or in places where there is no GPS connectivity. Without GPS the system can
+                   create only 1 hop links.";
+            }
+            enum gps-sync {
+                description
+                  "Regular sync. RF links will drop when the unit will lose GPS sync.";
+            }
+            enum gps-sync-holdover {
+                description
+                  "RF links will not drop when the unit will lose GPS sync. This mode will be a
+                   default sync mode for all N3XX devices.";
+            }
+            enum rf-sync {
+                description
+                  "The device will use the HTSF feature to synchronize all
+                   RF sectors from the RF sync of the incoming RF link";
+            }
+        }
+        description
+          "Describes DN sync modes";
+    }
+
+    // grouping statements
+    grouping node-dn-top {
+        container node-config {
+            description
+              "The container includes all the configuration that are related to the entire TG unit.";
+            container default-radio-profile {
+                uses rb-tg-radio:radio-frequency;
+                uses rb-tg-radio:radio-polarity;
+                uses rb-tg-radio:radio-golay-index;
+                description
+                  "Defaults for radio configuration (Rx-Tx). Applies to sectors when they have no specified radio configuration.";
+            }
+            leaf is-pop-dn {
+                type boolean;
+                description
+                  "Define this as a POP-DN or a regular Node";
+            }
+            leaf sync-mode {
+                type dn-sync-mode-type;
+                default gps-sync-holdover;
+                description
+                  "Specify how the node will synchronize with other nodes on the network";
+            }
+        }
+        description
+          "Grouping for node configuration and defaults";
+    }
+    grouping sectors-dn-top {
+        container sectors-config {
+            description
+              "Contain all parameters for sectors.";
+            list sector {
+                key index;
+                leaf index {
+                    type rb-tg-types:radio-sector-index;
+                    description
+                      "The index of the sector.";
+                }
+                // container ssid-profile {
+                // uses ssid-profile;
+                // description
+                // "SSID configuration. 
+                // Must be configured if the respective parameters are unspecified in default-ssid-profile, otherwise overrides them.";
+                // }
+                container radio-profile {
+                    uses rb-tg-radio:radio-frequency;
+                    uses rb-tg-radio:radio-polarity;
+                    uses rb-tg-radio:radio-golay-index;
+                    description
+                      "Radio configuration (Rx-Tx).
+                        Must be configured if the respective parameters are unspecified in default-radio-profile, otherwise overrides them.";
+                }
+                description
+                  "List of all sectors";
+            }
+        }
+        description
+          "Grouping for sectors configuration and default configuration data.";
+    }
+
+    grouping configured-link-top {
+        description
+          "Configuration for a link";
+        leaf remote-assigned-name {
+            type rb-tg-types:node-assigned-name;
+            description
+              "The netowrk assigned name/ID (AN) of the remote unit to which a link is defined.";
+        }
+
+        list remote-sector {
+            key index;
+            leaf index {
+                type rb-tg-types:radio-sector-index;
+                description
+                  "The index of the sector";
+            }
+            // min-elements 1; // TODO(itziks): in the future we will not need to set remote sector if responder-node-type=cn (i.e. TU)
+            description
+              "A list of sectors on the remote unit, to which the link can be setup.";
+        }
+
+        list local-sector {
+            key index; // TODO(itziks): index must exist in sectors list
+            leaf index {
+                type rb-tg-types:radio-sector-index;
+                description
+                  "The index of the sector";
+            }
+            // min-elements 1; // TODO(itziks)
+            description
+              "A list of sectors on the local unit, from which the link can be setup.";
+        }
+
+        leaf control-superframe {
+            type rb-tg-radio:control-superframe;
+            // TODO(itziks): enforce constraints based on responder-node-type (see description below)
+            mandatory true;
+            description
+              "If responder-node-type = CN: must be set to unspecified.
+               If responder-node-type = node/DN: can be either 0 or 1, but different between remote DNs on the same local sector 
+               (can be max. 2 node-node links per sector)";
+        }
+
+        leaf responder-node-type {
+            type rb-tg-radio:node-type;
+            description
+              "The requested node-type of the remote unit. The link will be rejected if the remote unit is already 
+               configured to a different type by another active link";
+        }
+
+        leaf admin-status {
+            type rb-tg-types:admin-status;
+            default up;
+            description
+              "Defines whether to initiate the link (and keep it up) or drop it (in case it was already established)";
+        }
+
+        leaf tx-power-control {
+            type rb-tg-radio:tx-power-control-type;
+            description
+              "lock txPower to 6, 31, auto for purpose of naive alignment";
+        }
+    }
+
+    grouping dn-link-state {
+        description
+          "Contains information of ignition process";
+
+        container state {
+            leaf state {
+                type dn-link-state-type;
+                config false;
+                description
+                  "Explains state of ignition process";
+            }
+            uses rb-tg-radio:disconnected-link-state;
+            description
+              "Aggregates state and down-cause together";
+        }
+    }
+
+    grouping golay-group {
+        leaf tx-golay-index {
+            type rb-tg-radio:golay-index;
+            description
+              "Tx Golay index of Golay code sequence";
+        }
+        leaf rx-golay-index {
+            type rb-tg-radio:golay-index;
+            description
+              "Rx Golay index of Golay code sequence";
+        }
+        description
+          "For overriding node/sector configuration from link";
+    }
+
+    grouping links-dn-top {
+        container links {
+            list configured {
+                uses configured-link-top;
+                uses dn-link-state;
+                uses golay-group;
+                key remote-assigned-name;
+
+                description
+                  "A list of all links that the node will try to initiate.";
+            }
+            description
+              "Contains lists of all defined links in this node.";
+        }
+        description
+          "Contains all links configuration";
+    }
+
+    grouping radio-dn-top {
+        container radio-dn {
+            description
+              "Top level container for TG node radio";
+            uses node-dn-top;
+            uses sectors-dn-top;
+            uses links-dn-top;
+        }
+        description
+          "Top level grouping of radio data";
+    }
+
+    // data definition statements
+    uses radio-dn-top;
+// augment statements
+// rpc statements
+}
+// notification statements
+

--- a/tests/serialise/xml-deserialise/radio-bridge-tg-types.yang
+++ b/tests/serialise/xml-deserialise/radio-bridge-tg-types.yang
@@ -1,0 +1,234 @@
+module radio-bridge-tg-types {
+
+    yang-version "1";
+
+    // namespace
+    namespace "http://siklu.com/yang/tg/types";
+
+    prefix "rb-tg-types";
+
+    // meta
+    organization
+      "Siklu";
+
+    contact
+      "Support: <https://siklu.com/contact/>";
+
+    description
+      "Definitions for the user bridge on TG Radio-bridge devices";
+
+    revision 2021-05-25 {
+        description
+          "Release";
+        reference
+          "";
+    }
+
+    revision 2020-09-15 {
+        description
+          "Initial revision";
+        reference
+          "TBD";
+    }
+
+    // extension statements
+    // feature statements
+    // identity statements
+    // typedef statements  
+    typedef radio-bridge-tg-string {
+        type string {
+            pattern
+              '[!#%-*,->@-Z^-~]+';
+        }
+        description
+          "Includes all printable characters, besides the characters ?$[]+ backslash, double quotes and spaces. 
+           This is according to our CLI limitations and some of Cisco's rules here:
+           https://www.cisco.com/assets/sol/sb/WAP321_Emulators/WAP321_Emulator_v1.0.0.3/help/Wireless05.html#:~:text=The%20SSID%20can%20be%20any,%5C%2C%20%5D%2C%20and%20%2B.
+          ";
+    }
+    typedef radio-sector-index {
+        type uint8 {
+            range "1 .. 4";
+        }
+        description
+          "Index of a radio sector";
+    }
+
+    typedef vlan-id {
+        type uint16 {
+            range "1 .. 4094";
+        }
+        description
+          "VLAN ID";
+    }
+
+    typedef ipv4-prefix-length {
+        type uint8 {
+            range 1..32;
+        }
+        description
+          "An IPv4 prefix length";
+    }
+
+    typedef node-assigned-name {
+        type string{
+            pattern
+              "[a-z0-9.-]{1,8}";
+        }
+        description
+          "Netowk name/ID assigned to the node (AN).";
+    }
+
+    typedef admin-status {
+        type enumeration {
+            enum up {
+                description
+                  "configured to be up";
+            }
+            enum down {
+                description
+                  "configured to be down";
+            }
+        }
+        description
+          "the admin status, can be either enabled/up or disabled/down";
+    }
+
+    typedef oper-status {
+        type enumeration {
+            enum up {
+                value 1;
+                description
+                  "Is operational.";
+            }
+            enum down {
+                value 2;
+                description
+                  "Is not operational.";
+            }
+            enum testing {
+                value 3;
+                description
+                  "In some test mode. No operational data can
+                   be passed.";
+            }
+            enum unknown {
+                value 4;
+                description
+                  "Status cannot be determined for some reason.";
+            }
+            enum dormant {
+                value 5;
+                description
+                  "Waiting for some external event.";
+            }
+            enum not-present {
+                value 6;
+                description
+                  "Some component (typically hardware) is missing.";
+            }
+            enum lower-layer-down {
+                value 7;
+                description
+                  "Down due to state of lower-layer interface(s).";
+            }
+        }
+        description
+          "The current operational state of the interface.";
+    }
+
+    typedef host-interface-name {
+        type string{
+            pattern
+              "host"; // TODO(itziks): add beginning and end of expression.
+        }
+        description
+          "Host interface name";
+    }
+
+    typedef rf-auto-connect-interface-name {
+        type string{
+            pattern
+              "rf";
+        }
+        description
+          "RF auto-connect interface name";
+    }
+
+    typedef embedded-interface-name {
+        type rb-tg-types:radio-bridge-tg-string {
+            length "1..32";
+        }
+        description
+          "Port interface name";
+    }
+
+    typedef rf-interface-name {
+        type string{
+            pattern
+              "rf-[ a-z0-9.-]{1,8}";
+        }
+        description
+          "RF interface name";
+    }
+
+    typedef temperature-celsius {
+        type int16;
+        units "Degrees in Celsius";
+        description
+          "Temperature (Celsius)";
+    }
+
+    typedef value-not-available {
+        type string{
+            pattern
+              "N/A";
+        }
+        description
+          "Value not available";
+    }
+
+    typedef yes_no {
+        type enumeration {
+            enum yes {
+                description
+                  "yes";
+            }
+            enum no {
+                description
+                  "no";
+            }
+        }
+        description
+          "yes or no";
+    }
+
+    typedef date {
+        type string {
+            pattern
+              '\d{4}-\d{2}-\d{2}';
+        }
+        description
+          "The date type is a profile of the ISO 8601
+           standard for representation of dates and times using the
+           Gregorian calendar.  The profile is defined by the
+           date-time production in Section 5.6 of RFC 3339.";
+    }
+
+    typedef time {
+        type string {
+            pattern
+              '\d{2}:\d{2}:\d{2}';
+        }
+        description
+          "The time type is a profile of the ISO 8601
+           standard for representation of dates and times using the
+           Gregorian calendar.  The profile is defined by the
+           date-time production in Section 5.6 of RFC 3339.";
+    }
+// grouping statements
+// data definition statements
+// augment statements
+// rpc statements
+// notification statements
+}

--- a/tests/serialise/xml-deserialise/run_siklu.py
+++ b/tests/serialise/xml-deserialise/run_siklu.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import os.path
+import unittest
+
+from lxml import objectify
+
+from pyangbind.lib.serialise import pybindIETFXMLDecoder, pybindIETFXMLEncoder
+from tests.base import PyangBindTestCase
+from tests.serialise.xml_utils import xml_tree_equivalence
+
+
+class XMLDeserialiseTests(PyangBindTestCase):
+    #yang_files = ["ietf-xml-deserialise.yang", "augment.yang"]
+    yang_files = ["radio-bridge-tg-radio-dn.yang"]
+    maxDiff = None
+
+    def test_deserialise_full_container_roundtrip(self):
+        # with open(os.path.join(os.path.dirname(__file__), "xml", "obj.xml"), "r") as fp:
+        with open(os.path.join(os.path.dirname(__file__), "xml", "siklu.xml"), "r") as fp:
+
+            external_xml = fp.read()
+            existing_doc = objectify.fromstring(external_xml)
+
+        #result = pybindIETFXMLDecoder().decode(external_xml, self.bindings, "ietf_xml_deserialise")
+        result = pybindIETFXMLDecoder().decode(external_xml, self.bindings, "radio-bridge-tg-radio-dn")
+        doc = pybindIETFXMLEncoder().encode(result)
+
+        self.assertTrue(xml_tree_equivalence(doc, existing_doc), "Generated XML did not match the expected output.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/serialise/xml-deserialise/xml/siklu.xml
+++ b/tests/serialise/xml-deserialise/xml/siklu.xml
@@ -1,0 +1,9 @@
+<radio-bridge-tg-radio-dn xmlns="http://siklu.com/yang/tg/radio/dn">
+    <radio-dn>
+      <node-config>
+        <default-radio-profile>
+          <frequency>60480</frequency>
+        </default-radio-profile>
+      </node-config>
+    </radio-dn>
+  </radio-bridge-tg-radio-dn>


### PR DESCRIPTION
## Description
Support for Siklu pyangbind/tests,
Unit tests framework used for testing pyangbind functionality.

## Tests
tests/serialise/xml-deserialise/run_siklu.py
pybindIETFXMLEncoder() & pybindIETFXMLDecoder() validation using Siklu YANG input.


## References
JIRA: DEV-4416
