### PR TITLE
DEV-4412: Remove_distutils_version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+ This PR add support for the XYZ protocol. In order to add support for that protocol, we add to remove the support in protocol J (see commit Foo and Bar). 
+
+ The PR also adds unit-tests. 
+
+## Tests
+ * Tested that protocol XYZ is working
+ * Tested that a Spider N366 is bringing up a link. 
+
+## References
+JIRA: DEV-NUMBER

--- a/pyangbind/__init__.py
+++ b/pyangbind/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.1"
+__version__ = "0.8.1_siklu"

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,3 @@
-import distutils
 import importlib
 import inspect
 import os.path
@@ -60,9 +59,6 @@ class PyangBindTestCase(unittest.TestCase):
 
         if cls.yang_files is None:
             raise ValueError("cls.yang_files must be set")
-        pyang_path = distutils.spawn.find_executable("pyang")
-        if not pyang_path:
-            raise RuntimeError("Could not locate `pyang` executable.")
         base_dir = os.path.dirname(os.path.dirname(__file__))
         yang_files = [os.path.join(cls._test_path, filename) for filename in cls.yang_files]
         plugin_dir = os.path.join(base_dir, "pyangbind", "plugin")
@@ -73,7 +69,7 @@ class PyangBindTestCase(unittest.TestCase):
             flags.append("--split-class-dir {}".format(cls._pyang_generated_class_dir))
 
         pyang_cmd = "{pyang} --plugindir {plugins} -f pybind -p {test_path} {flags} {yang_files}".format(
-            pyang=pyang_path,
+            pyang="pyang",
             plugins=plugin_dir,
             test_path=cls._test_path,
             flags=" ".join(flags),


### PR DESCRIPTION
## Description
Support for pyangbind/tests as they cannot run,
Because every test member inherits PyangBindTestCase class (base.py) which currently uses distutils package to determine executables path, the package is not required and also obsolete, which prevents tests from running.


## References
JIRA: DEV-4412
