### PR TITLE
DEV-4481: pyangbind xml decoder does not support restricted yang values types which base type is string

### DIFF
--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -29,6 +29,7 @@ from decimal import Decimal
 import regex
 import six
 from bitarray import bitarray
+from lxml import objectify
 
 # Words that could turn up in YANG definition files that are actually
 # reserved names in Python, such as being builtin types. This list is
@@ -368,6 +369,9 @@ def RestrictedClassType(*args, **kwargs):
             if val is not False:
                 for test in self._restriction_tests:
                     passed = False
+                    # python 3 support for string base type
+                    if isinstance(val, objectify.StringElement):
+                        val = val.pyval
                     if test(val) is not False:
                         passed = True
                         break


### PR DESCRIPTION
## Description

pyangbind xml decoder fails on restricted yang values which corresponding bindings base type is string.

This seems to be an artifact of the 2 to 3 python conversion. In the RestrictedClassType in yangtypes.py, in the method mp_check there is a type check that looks for six types.

           def mp_check(value):
                if not isinstance(value, six.string_types + (six.text_type,)):
                    return False
                if regex.match(convert_regexp(regexp), value):
                    return True
                return False

            return mp_check
However if the type passed in is a Restricted type it is passed in as an lxml.objectify.StringElement.
This fails the check.
If instead of the lxml.objectify.StringElement you use the lxml.objectify.StringElement.pyval, it will work.

My solution was to add a type check before the call to mp_check.
in class RestrictedClass(base_type):

        if val is not False:
            for test in self._restriction_tests:
                passed = False
                if isinstance(val, objectify.StringElement):
                    val = val.pyval
                if test(val) is not False:
                    passed = True
                    break
            if not passed:
                raise ValueError("%s does not match a restricted type" % val)

## References
JIRA: 4481
